### PR TITLE
Fixed unzip issue

### DIFF
--- a/index.js
+++ b/index.js
@@ -24,7 +24,7 @@ const getUnZipCommand = (archivePath, directoryPath) => {
   if (isWin32()) {
     return `${bin} x -o${directoryPath} ${archivePath}`;
   } else {
-    return `unzip -o ${archivePath} -d ${archivePath}`;
+    return `unzip -o ${archivePath} -d ${directoryPath}`;
   }
 };
 


### PR DESCRIPTION
It wasn't using the directoryPath so unzip would complain
that the file already existed.
